### PR TITLE
fix(web): render landing page per-request so stats aren't zero

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -5,18 +5,30 @@ import { FeaturesSection } from '@/components/Landing/FeaturesSection';
 import { RecentPostsPreview } from '@/components/Landing/RecentPostsPreview';
 import { LandingFooter } from '@/components/Landing/LandingFooter';
 
+// Rendered per-request rather than prerendered at build time. The build runs
+// inside Docker/CI where the public API is not reachable, so a prerender would
+// bake in the fallback zeros — and on Cloud Run (min-instances 0) background
+// ISR regeneration never survives long enough to replace them.
+export const dynamic = 'force-dynamic';
+
 export default async function LandingPage() {
   const [stats, recentPosts] = await Promise.all([
-    statsApi.getStats().catch(() => ({
-      users: 0,
-      posts: 0,
-      claims_analyzed: 0,
-      concepts_mapped: 0,
-    })),
+    statsApi.getStats().catch((err) => {
+      console.error('[landing] stats fetch failed:', err);
+      return {
+        users: 0,
+        posts: 0,
+        claims_analyzed: 0,
+        concepts_mapped: 0,
+      };
+    }),
     postsApi
       .getFeed('new', 6)
       .then((res) => res.items)
-      .catch(() => []),
+      .catch((err) => {
+        console.error('[landing] recent posts fetch failed:', err);
+        return [];
+      }),
   ]);
 
   return (


### PR DESCRIPTION
The landing page was statically prerendered, so its stats and recent-posts fetches ran during the Docker build in CI, where the public API is not reachable. The catch fallbacks (all zeros, empty post list) were baked into the HTML, and with the web service at min-instances 0 on Cloud Run the background ISR regeneration never survived to replace them.

Force dynamic rendering so both fetches hit the live API on each request, and log fetch failures instead of swallowing them silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Landing page data is now refreshed on each request instead of relying on build-time or cached content.
  * Improved error visibility when loading statistics or recent posts, while preserving fallback content if requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->